### PR TITLE
sign.sh: Use env program to find bash executable instead of hardcoding its path

### DIFF
--- a/sign.sh
+++ b/sign.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # uncomment this for debug.
 # set -o xtrace


### PR DESCRIPTION
Just a bit feeling of better practice, feel free to deny it.

Signed-off-by: Lin-Buo-Ren <Buo.Ren.Lin@gmail.com>